### PR TITLE
Add --no-window flag to godot build

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -165,6 +165,7 @@ application/modify_resources=false
         }
 
         let status = std::process::Command::new(godot_path)
+            .arg("--no-window")
             .arg("--path")
             .arg(&godot.parent().expect("Failed to get parent directory"))
             .arg("--export-pack")


### PR DESCRIPTION
If this works it should open up the godot editor in windowless mode.