### PR TITLE
hack to skip .deps.json and .pdb on zip generation

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -76,9 +76,12 @@ fn zip_dir(
     for entry in std::fs::read_dir(path)? {
         let entry = entry?;
         let path = entry.path();
-
         if let Some(file_name) = path.file_name() {
-            if ignore.contains(&file_name.to_string_lossy().to_string()) {
+            // a bit of a hacky way of stripping unnecessary dll compilation files from the zips, hopefully that's ok!
+            let lossy_string = file_name.to_string_lossy().to_string();
+            if ignore.contains(&lossy_string)
+                || lossy_string.ends_with(".deps.json")
+                || lossy_string.ends_with(".pdb") {
                 continue;
             }
         }


### PR DESCRIPTION
I remember you reminding everyone that only the dll is required for mods (duh) so when I noticed this was happening when using manifestation I thought making this soft subtle pull request would be a good excuse to write rust again.

ik people can just exclude the things from being generated with rider/vscode or the csproj but you know, might as well skip them from the zips regardless since they're not needed for mod distribution.

love u /p